### PR TITLE
Fixing kubectl image location for new sub chart req

### DIFF
--- a/charts/cray-velero/values.yaml
+++ b/charts/cray-velero/values.yaml
@@ -121,3 +121,8 @@ velero:
         # https://github.com/vmware-tanzu/velero/issues/2335
         # https://github.com/restic/restic/issues/2656
         s3Url: 'http://rgw-vip.nmn'
+
+  kubectl:
+    image: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope
Fixing kubectl image location for new sub chart req

## Issues and Related PRs

* Resolves Jira is down - will update if it gets back online

## Testing

### Tested on:

  * surtur

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

