### PR TITLE
bumping kubectl version

### DIFF
--- a/charts/cray-velero/Chart.yaml
+++ b/charts/cray-velero/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-velero
-version: 1.7.1-1
+version: 1.7.1-2
 description: Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes
 keywords:
   - velero

--- a/charts/cray-velero/Chart.yaml
+++ b/charts/cray-velero/Chart.yaml
@@ -51,7 +51,7 @@ annotations:
           url: https://github.com/Cray-HPE/cray-velero/pull/2
   artifacthub.io/images: |
     - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.21.12
     - name: velero
       image: artifactory.algol60.net/csm-docker/stable/velero/velero:v1.7.1
     - name: velero-plugin-for-aws

--- a/charts/cray-velero/values.yaml
+++ b/charts/cray-velero/values.yaml
@@ -25,7 +25,7 @@
 # Used for Helm Hooks
 kubectl:
   image: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-  tag: 1.19.15
+  tag: 1.21.12
   pullPolicy: IfNotPresent
 
 velero:
@@ -43,7 +43,7 @@ velero:
           name: plugins
     # Init container to convert Storage IAM Secrets to Standard S3 Format
     - name: convert-credentials
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.21.12
       command:
       - 'sh'
       - '-c'
@@ -65,7 +65,7 @@ velero:
             key: secret_key
     # Init container to update backup storage location from Storage IAM Secrets
     - name: update-bsl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.21.12
       command:
       - 'sh'
       - '-c'
@@ -125,5 +125,5 @@ velero:
   kubectl:
     image:
       repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-      tag: 1.19.15
+      tag: 1.21.12
       pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope
Running into compatibility issue with the older kubectl version and velero in 1.3.
will now use docker-kubectl:v1.21.12

## Issues and Related PRs

* Resolves CASMPET-5779

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

