### PR TITLE
CASMPET-7221-velero-1.6 update docker-kubectl version to 1.24.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		cray-velero
 
 package:

--- a/charts/cray-velero/Chart.yaml
+++ b/charts/cray-velero/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022,2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-velero
-version: 1.6.3-2
+version: 1.6.3-3
 description: Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes
 keywords:
   - velero
@@ -51,7 +51,7 @@ annotations:
           url: https://github.com/Cray-HPE/cray-velero/pull/2
   artifacthub.io/images: |
     - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
     - name: velero
       image: artifactory.algol60.net/csm-docker/stable/velero/velero:v1.6.3
     - name: velero-plugin-for-aws

--- a/charts/cray-velero/values.yaml
+++ b/charts/cray-velero/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022,2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@
 # Used for Helm Hooks
 kubectl:
   image: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-  tag: 1.19.15
+  tag: 1.24.17
   pullPolicy: IfNotPresent
 
 velero:
@@ -43,7 +43,7 @@ velero:
           name: plugins
     # Init container to convert Storage IAM Secrets to Standard S3 Format
     - name: convert-credentials
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       command:
       - 'sh'
       - '-c'
@@ -65,7 +65,7 @@ velero:
             key: secret_key
     # Init container to update backup storage location from Storage IAM Secrets
     - name: update-bsl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
       command:
       - 'sh'
       - '-c'
@@ -125,5 +125,5 @@ velero:
   kubectl:
     image:
       repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-      tag: 1.19.15
+      tag: 1.24.17
       pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

For k8s 1.24 in CSM 1.6, the docker-kubectl container image should be updated so that it is using version 1.24.17.

## Issues and Related PRs

* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

### Tested on:

  * Beau, vshasta2

### Test description:

I tested a cray-velero chart upgrade and an install.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

