### PR TITLE
CASMPET-7554: upgrading velero chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		cray-velero
 
 package:

--- a/charts/cray-velero/Chart.yaml
+++ b/charts/cray-velero/Chart.yaml
@@ -23,14 +23,14 @@
 #
 apiVersion: v2
 name: cray-velero
-version: 1.7.1-1
+version: 1.16.1
 description: Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes
 keywords:
   - velero
 home: https://github.com/Cray-HPE/cray-velero
 dependencies:
   - name: velero
-    version: 2.27.5
+    version: 10.0.1
     repository: https://vmware-tanzu.github.io/helm-charts
 maintainers:
   - name: bklei
@@ -39,7 +39,7 @@ icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 sources:
 - https://github.com/vmware-tanzu/velero
 - https://github.com/vmware-tanzu/helm-charts
-appVersion: 2.27.5
+appVersion: 10.0.1
 annotations:
   artifacthub.io/changes: |
     - kind: security
@@ -50,12 +50,12 @@ annotations:
         - name: Github PR
           url: https://github.com/Cray-HPE/cray-velero/pull/2
   artifacthub.io/images: |
-    - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+    - name: kubectl
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
     - name: velero
-      image: artifactory.algol60.net/csm-docker/stable/velero/velero:v1.7.1
+      image: artifactory.algol60.net/csm-docker/stable/velero/velero:v1.16.1
     - name: velero-plugin-for-aws
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/velero/velero-plugin-for-aws:v1.3.1
-    - name: velero-restic-restore-helper
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/velero/velero-restic-restore-helper:v1.7.1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/velero/velero-plugin-for-aws:v1.12.1
+    - name: velero-restore-helper
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/velero/velero-restore-helper:v1.15.1
   artifacthub.io/license: MIT

--- a/charts/cray-velero/values.yaml
+++ b/charts/cray-velero/values.yaml
@@ -22,28 +22,32 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+
 # Used for Helm Hooks
 kubectl:
-  image: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-  tag: 1.19.15
+  image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+  tag: 1.33.1
   pullPolicy: IfNotPresent
 
 velero:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/velero/velero
-    tag: v1.7.1
+    tag: v1.16.1
+
+  nameOverride: velero
+  fullnameOverride: velero
 
   initContainers:  # Cannot patch in partial lists to upstream chart
     # AWS plugin for velero
     - name: velero-plugin-for-aws
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/velero/velero-plugin-for-aws:v1.3.1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/velero/velero-plugin-for-aws:v1.12.1
       imagePullPolicy: IfNotPresent
       volumeMounts:
         - mountPath: /target
           name: plugins
     # Init container to convert Storage IAM Secrets to Standard S3 Format
     - name: convert-credentials
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
       command:
       - 'sh'
       - '-c'
@@ -65,7 +69,7 @@ velero:
             key: secret_key
     # Init container to update backup storage location from Storage IAM Secrets
     - name: update-bsl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
       command:
       - 'sh'
       - '-c'
@@ -82,17 +86,17 @@ velero:
             key: http_s3_endpoint
 
   configMaps:
-    restic-restore-action-config:  # required to override image...
+    fs-restore-action-config:  # required to override image...
       labels:
         velero.io/plugin-config: ""
-        velero.io/restic: RestoreItemAction
+        velero.io/pod-volume-restore: RestoreItemAction
       data:
-        image: artifactory.algol60.net/csm-docker/stable/docker.io/velero/velero-restic-restore-helper:v1.7.1
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/velero/velero-restore-helper:v1.15.1
 
   # Use restic for pod volume backups
   # note limitations here: https://velero.io/docs/v1.0.0/restic/#limitations
   snapshotsEnabled: false
-  deployRestic: true
+  deployNodeAgent: true
 
   # This secret is created by a post-helm hook in this chart
   # The source is a secret created by the ceph installer
@@ -100,11 +104,11 @@ velero:
     existingSecret: velero-iam
 
   configuration:
-    provider: aws
 
     # https://velero.io/docs/v1.5/api-types/backupstoragelocation/
     backupStorageLocation:
-      bucket: velero
+    - bucket: velero
+      provider: aws
       config:
         region: default  # arbitrary, not currently utilized by Ceph RGW in product
 
@@ -124,6 +128,6 @@ velero:
 
   kubectl:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-      tag: 1.19.15
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+      tag: 1.33.1
       pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope

velero is being upgraded to 1.16.1 along with velero-plugin-for-aws and velero-restore-helper to the compatible versions.

## Issues and Related PRs

* Resolves [CASMPET-7554](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7554)
* https://github.com/Cray-HPE/container-images/pull/705
* https://github.com/Cray-HPE/node-images/pull/1259

## Testing

the unstable cray-velero chart was deployed on the cluster and velero commands were ran according to documentation.
https://spiraplan-pro-ext.it.hpe.com/SpiraPlan/3714/TestCase/List.aspx

### Tested on:

  * starlord

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

